### PR TITLE
Display any Particle.io registration errors

### DIFF
--- a/config.html
+++ b/config.html
@@ -112,6 +112,7 @@ $(function() {
 	  $('#login_register').attr('disabled',false);
 	  if(body === null){
 	  	$('#login_password').val("");
+	  	$('#login_error').html("Invalid email or password.");
 	  	$('#login_error').show();
 	  }
 	  else{
@@ -518,7 +519,8 @@ function comm_error_retry(){
 	    $('#login_button').click();
 	  }
 	  else{
-	  	//TODO SHOW ERROR HERE
+	  	$('#login_error').html(err.message);
+	  	$('#login_error').show();
 	  	$('#login_button').attr('disabled',false);
 	  	$('#login_register').attr('disabled',false);
 	  }


### PR DESCRIPTION
To date, the code that checked for errors upon attempting to register an
account with Particle.io contained only a TODO placeholder indicating
that any errors should be shown to the user.

This commit displays the contents of err.message in the login_error html
div that is already used to display a login error. Because the contents
of this div are modified, it was necessary to extend the login error
handling code to reset the message if there is a subsequent login error.
I tried modifying this code to also display err.message, as I hoped it
would give more fine grained messages, but it turned out they were not
user friendly (I got "invalid_client" and "invalid_grant". Therefore, I
kept the existing login error string "Invalid email or password".

I don't know the full range of registration error messages that can be
generated, so it's possible that some of these may not be user
friendly. However, for the error I encountered, the message was
appropriate: "Username must be an email address".

I was attempting to register with the username+string@gmail.com address
format that is recommended by GMail for filtering and spam tracking. No
error message was displayed, which led to some head scratching until I
started debugging the code and found this message. It appears
Particle.io does not support this email address format.
